### PR TITLE
Instead of specifying a manifest file use all files in a folder

### DIFF
--- a/cerberus_components/cms/config.pp
+++ b/cerberus_components/cms/config.pp
@@ -1,4 +1,4 @@
-node default {
+class cerberus::cms::config {
   # Make sure we have the /opt/cerberus directory for placing the server artifacts/scripts in a known location.
   file { '/opt/cerberus/' :
     ensure   => directory,

--- a/cerberus_components/cms/init.pp
+++ b/cerberus_components/cms/init.pp
@@ -1,0 +1,5 @@
+node default {
+
+  include cerberus::cms::config
+
+}

--- a/cerberus_components/gateway/config.pp
+++ b/cerberus_components/gateway/config.pp
@@ -1,0 +1,3 @@
+class cerberus::gateway::config {
+  include 'gateway'
+}

--- a/cerberus_components/gateway/init.pp
+++ b/cerberus_components/gateway/init.pp
@@ -1,0 +1,5 @@
+node default {
+
+  include cerberus::gateway::config
+
+}

--- a/cerberus_components/gateway/manifest.pp
+++ b/cerberus_components/gateway/manifest.pp
@@ -1,3 +1,0 @@
-node default {
-  include 'gateway'
-}

--- a/cms-packer.json
+++ b/cms-packer.json
@@ -104,7 +104,7 @@
     },
     {
       "type"              : "puppet-masterless",
-      "manifest_file"     : "cerberus_components/cms/manifest.pp",
+      "manifest_file"     : "cerberus_components/cms",
       "staging_directory" : "/tmp",
       "execute_command"   : "{{.FacterVars}}{{if .Sudo}} sudo -E {{end}}puppet apply --verbose --detailed-exitcodes --modulepath='/opt/puppet/modules' {{.ManifestFile}}"
     }

--- a/packer.json
+++ b/packer.json
@@ -72,7 +72,7 @@
       ]
     }, {
       "type"              : "puppet-masterless",
-      "manifest_file"     : "cerberus_components/{{user `cerberus_component`}}/manifest.pp",
+      "manifest_file"     : "cerberus_components/{{user `cerberus_component`}}",
       "staging_directory" : "/tmp",
       "execute_command"   : "{{.FacterVars}}{{if .Sudo}} sudo -E {{end}}puppet apply --verbose --detailed-exitcodes --modulepath='/opt/puppet/modules' {{.ManifestFile}}"
     }


### PR DESCRIPTION
Leverage the advantages packer and puppet provides w.r.t puppet manifests. Instead of specifying a particular manifest .pp, lets provide the folder path. Let puppet load all .pp in that folder. This gives opportunity for users to add more customizations just by adding more .pp.
Also updated names spaces for better.