### PR TITLE
CMS upstart to wait until instance tags are propagated and puppet bootstrap updates for vault and consul

### DIFF
--- a/bash_scripts/cms_signal.conf
+++ b/bash_scripts/cms_signal.conf
@@ -26,11 +26,13 @@ script
   echo "Instance ID : ${ID}"
   echo "Stack ID : ${STACK_ID}"
 
+  echo 'Waiting for CMS services to come alive'
   while ! curl -s -o /dev/null -I -w "%{http_code}" http://localhost:8080/healthcheck | grep -q '200' ;
   do
-   echo 'Waiting for CMS services to come alive'
+   echo -n '.'
    sleep 1
   done
+  echo '*'
   echo 'CMS services are healthy'
 
   # Single to AWS that we are up

--- a/bash_scripts/cms_signal.conf
+++ b/bash_scripts/cms_signal.conf
@@ -21,9 +21,25 @@ script
 
   URL="http://169.254.169.254/latest/"
   ID=$(curl -s $URL/meta-data/instance-id)
+  echo "Instance ID : ${ID}"
+
+  EC2_AVAIL_ZONE=`curl -s $URL/meta-data/placement/availability-zone`
+  EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
+  echo "EC2_AVAIL_ZONE : ${EC2_AVAIL_ZONE}"
+  echo "EC2_REGION : ${EC2_REGION}"
+
   STACK_ID=$(aws ec2 describe-tags --region ${EC2_REGION} --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
 
-  echo "Instance ID : ${ID}"
+  # Tags may not be available for use with newly launched instances. Eventhough its rare, it happens.
+  # We have seen it 1 out of 6 times. Make sure we got stack id.
+
+  echo "Check and wait while we have STACK_ID from AWS instance tags"
+  while [ -z $STACK_ID ]; do
+    echo -n "."
+    sleep 1
+    STACK_ID=$(aws ec2 describe-tags --region ${EC2_REGION} --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
+  done
+  echo '*'
   echo "Stack ID : ${STACK_ID}"
 
   echo 'Waiting for CMS services to come alive'

--- a/cerberus_components/consul/config.pp
+++ b/cerberus_components/consul/config.pp
@@ -1,6 +1,8 @@
-node default {
+class cerberus::consul::config {
+
   class { 'consul':
     consul_run_mode => 'server',
     bootstrap_expect => '3',
   }
+
 }

--- a/cerberus_components/consul/init.pp
+++ b/cerberus_components/consul/init.pp
@@ -1,0 +1,5 @@
+node default {
+
+  include cerberus::consul::config
+
+}

--- a/cerberus_components/vault/config.pp
+++ b/cerberus_components/vault/config.pp
@@ -1,7 +1,9 @@
-node default {
+class cerberus::vault::config {
+
   class { 'consul':
     consul_run_mode => 'agent',
   }
 
   include 'vault'
+
 }

--- a/cerberus_components/vault/init.pp
+++ b/cerberus_components/vault/init.pp
@@ -1,0 +1,5 @@
+node default {
+
+  include cerberus::vault::config
+
+}


### PR DESCRIPTION
CMS upstart to wait until instance tags are propagated and puppet bootstrap updates for vault and consul