### PR TITLE
Packer to Copy Additional Files to CMS AMI

### DIFF
--- a/additional_files/README.md
+++ b/additional_files/README.md
@@ -1,0 +1,8 @@
+# Additional Files
+
+Place files in this folder to be uploaded to the file system on the Cerberus
+Management Service (CMS) AMI.
+
+When the Packer JSON file for CMS (`cms-packer.json`) is executed, all files in
+this directory will be uploaded to the `/tmp` directory on the newly baked CMS
+AMI.

--- a/additional_files/README.md
+++ b/additional_files/README.md
@@ -5,4 +5,5 @@ Management Service (CMS) AMI.
 
 When the Packer JSON file for CMS (`cms-packer.json`) is executed, all files in
 this directory will be uploaded to the `/tmp` directory on the newly baked CMS
-AMI.
+AMI.  These files can then be used to apply additional customizations to the AMI
+that make sense for your company (e.g. vendor specific metrics and/or monitoring).

--- a/cms-packer.json
+++ b/cms-packer.json
@@ -84,6 +84,11 @@
       "destination" : "/tmp/cms_signal.conf"
     },
     {
+      "type" : "file",
+      "source" : "cerberus_components/additional_files/",
+      "destination" : "/tmp"
+    },
+    {
       "type" : "shell",
       "inline": [
         "wget {{user `cms_jar_url`}} -O /tmp/app-server.jar"


### PR DESCRIPTION
This change tells Packer to upload all files in the `additional_files` directory to `/tmp` on the CMS AMI file system.