### PR TITLE
Ensure CMS deploy rolls back if success signal is never sent

### DIFF
--- a/bash_scripts/cms_signal.conf
+++ b/bash_scripts/cms_signal.conf
@@ -42,15 +42,14 @@ script
   echo '*'
   echo "Stack ID : ${STACK_ID}"
 
-# TODO CHANGE BACK BEFORE MERGE
-  #echo 'Waiting for CMS services to come alive'
-  #while ! curl -k -s -o /dev/null -I -w "%{http_code}" https://localhost:8443/healthcheck | grep -q '200' ;
-  #do
-  # echo -n '.'
-  # sleep 1
-  #done
-  #echo '*'
-  #echo 'CMS services are healthy'
+  echo 'Waiting for CMS services to come alive'
+  while ! curl -k -s -o /dev/null -I -w "%{http_code}" https://localhost:8443/healthcheck | grep -q '200' ;
+  do
+   echo -n '.'
+   sleep 1
+  done
+  echo '*'
+  echo 'CMS services are healthy'
 
   # Single to AWS that we are up
   echo 'Sending CMS CF signal'


### PR DESCRIPTION
Uncommenting this to ensure rollback if deploy is unsuccessful.